### PR TITLE
A couple of performance fixes

### DIFF
--- a/src/js/main/KidaptiveAlpPlugin.js
+++ b/src/js/main/KidaptiveAlpPlugin.js
@@ -229,7 +229,7 @@
 
       // since we're in a container, attempt to fetch configuration from outside.
       // However, we'll provide a timeout just in case the container's not listening
-      var MAX_WAIT_TIME = 1000;
+      var MAX_WAIT_TIME = 50;
       var successState = null;
       var timeout = setTimeout(function() {
         if(successState !== null) {

--- a/src/js/main/KidaptiveAlpPlugin.js
+++ b/src/js/main/KidaptiveAlpPlugin.js
@@ -204,6 +204,9 @@
               }
           }.bind(this)).then(function() {
               done();
+          }).catch(function(e) {
+            console.error('Kidaptive ALP failed to initialize', e);
+            done();
           });
         }.bind(this));
     };


### PR DESCRIPTION
- I've added error handling (the best that SpringRoll can currently support) for the `KidaptiveSDK.init` method. SpringRoll `preload` tasks don't have error handling apparently, but we can at least log an error when it occurs.
- I've also bumped down the timeout drastically on waiting for configs to be posted from the container. In my measurements we generally would receive a response from the container (with configs) in 5ms or less. I bumped up the time a tad just in case lower-end devices have trouble. This way games using this plugin won't have a huge noticeable delay during start up when running outside of a container.